### PR TITLE
Update to new upstream release 0.10.0

### DIFF
--- a/docker-io.spec
+++ b/docker-io.spec
@@ -13,7 +13,7 @@
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           docker-io
-Version:        0.9.1
+Version:        0.10.0
 Release:        1%{?dist}
 Summary:        Automates deployment of containerized applications
 License:        ASL 2.0
@@ -36,6 +36,8 @@ BuildRequires:  glibc-static
 BuildRequires:  golang >= 1.2-7
 BuildRequires:  golang(github.com/gorilla/mux)
 BuildRequires:  golang(github.com/kr/pty)
+BuildRequires:  golang(github.com/godbus/dbus)
+BuildRequires:  golang(github.com/coreos/go-systemd)
 BuildRequires:  golang(code.google.com/p/go.net/websocket)
 BuildRequires:  golang(code.google.com/p/gosqlite/sqlite3)
 BuildRequires:  golang(github.com/syndtr/gocapability/capability)
@@ -196,6 +198,9 @@ fi
 %{_datadir}/vim/vimfiles/syntax/dockerfile.vim
 
 %changelog
+* Wed Apr 09 2014 Bobby Powers <bobbypowers@gmail.com> - 0.10.0-1
+- Upstream version bump
+
 * Thu Mar 27 2014 Lokesh Mandvekar - 0.9.1-1
 - BZ 1080799 - upstream version bump
 

--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-194ee07653abb984bbbab0cf0f3b98f3  v0.9.1.tar.gz
+1a9b569b1627a51b0ce6e85eaad459c4  v0.10.0.tar.gz

--- a/upstream-patched-archive-tar.patch
+++ b/upstream-patched-archive-tar.patch
@@ -1,7 +1,8 @@
-diff -uNr docker-0.9.0/archive/archive.go docker-0.9.0-1/archive/archive.go
---- docker-0.9.0/archive/archive.go	2014-03-10 12:57:10.000000000 -0400
-+++ docker-0.9.0-1/archive/archive.go	2014-03-11 10:35:04.577207349 -0400
-@@ -8,7 +8,7 @@
+diff --git a/archive/archive.go b/archive/archive.go
+index 2fac18e..634e9c1 100644
+--- a/archive/archive.go
++++ b/archive/archive.go
+@@ -8,7 +8,7 @@ import (
  	"fmt"
  	"github.com/dotcloud/docker/pkg/system"
  	"github.com/dotcloud/docker/utils"
@@ -10,10 +11,11 @@ diff -uNr docker-0.9.0/archive/archive.go docker-0.9.0-1/archive/archive.go
  	"io"
  	"io/ioutil"
  	"os"
-diff -uNr docker-0.9.0/archive/archive_test.go docker-0.9.0-1/archive/archive_test.go
---- docker-0.9.0/archive/archive_test.go	2014-03-10 12:57:10.000000000 -0400
-+++ docker-0.9.0-1/archive/archive_test.go	2014-03-11 10:34:03.705484166 -0400
-@@ -3,7 +3,7 @@
+diff --git a/archive/archive_test.go b/archive/archive_test.go
+index 4126601..ca5a80c 100644
+--- a/archive/archive_test.go
++++ b/archive/archive_test.go
+@@ -3,7 +3,7 @@ package archive
  import (
  	"bytes"
  	"fmt"
@@ -22,10 +24,11 @@ diff -uNr docker-0.9.0/archive/archive_test.go docker-0.9.0-1/archive/archive_te
  	"io"
  	"io/ioutil"
  	"os"
-diff -uNr docker-0.9.0/archive/changes.go docker-0.9.0-1/archive/changes.go
---- docker-0.9.0/archive/changes.go	2014-03-10 12:57:10.000000000 -0400
-+++ docker-0.9.0-1/archive/changes.go	2014-03-11 10:34:40.196318221 -0400
-@@ -5,7 +5,7 @@
+diff --git a/archive/changes.go b/archive/changes.go
+index 723e4a7..51baa22 100644
+--- a/archive/changes.go
++++ b/archive/changes.go
+@@ -5,7 +5,7 @@ import (
  	"fmt"
  	"github.com/dotcloud/docker/pkg/system"
  	"github.com/dotcloud/docker/utils"
@@ -34,10 +37,11 @@ diff -uNr docker-0.9.0/archive/changes.go docker-0.9.0-1/archive/changes.go
  	"io"
  	"os"
  	"path/filepath"
-diff -uNr docker-0.9.0/archive/diff.go docker-0.9.0-1/archive/diff.go
---- docker-0.9.0/archive/diff.go	2014-03-10 12:57:10.000000000 -0400
-+++ docker-0.9.0-1/archive/diff.go	2014-03-11 10:34:25.722384042 -0400
-@@ -2,7 +2,7 @@
+diff --git a/archive/diff.go b/archive/diff.go
+index e20e4b1..a67b48a 100644
+--- a/archive/diff.go
++++ b/archive/diff.go
+@@ -2,7 +2,7 @@ package archive
  
  import (
  	"fmt"
@@ -46,10 +50,11 @@ diff -uNr docker-0.9.0/archive/diff.go docker-0.9.0-1/archive/diff.go
  	"io"
  	"io/ioutil"
  	"os"
-diff -uNr docker-0.9.0/archive/wrap.go docker-0.9.0-1/archive/wrap.go
---- docker-0.9.0/archive/wrap.go	2014-03-10 12:57:10.000000000 -0400
-+++ docker-0.9.0-1/archive/wrap.go	2014-03-11 10:34:15.296431455 -0400
-@@ -2,7 +2,7 @@
+diff --git a/archive/wrap.go b/archive/wrap.go
+index 03ea508..0abe320 100644
+--- a/archive/wrap.go
++++ b/archive/wrap.go
+@@ -2,7 +2,7 @@ package archive
  
  import (
  	"bytes"
@@ -58,22 +63,37 @@ diff -uNr docker-0.9.0/archive/wrap.go docker-0.9.0-1/archive/wrap.go
  	"io/ioutil"
  )
  
-diff -uNr docker-0.9.0/integration/api_test.go docker-0.9.0-1/integration/api_test.go
---- docker-0.9.0/integration/api_test.go	2014-03-10 12:57:10.000000000 -0400
-+++ docker-0.9.0-1/integration/api_test.go	2014-03-11 10:35:17.048150637 -0400
-@@ -11,7 +11,7 @@
- 	"github.com/dotcloud/docker/engine"
- 	"github.com/dotcloud/docker/runconfig"
+diff --git a/graph/tags_unit_test.go b/graph/tags_unit_test.go
+index 1777391..5cfe4c2 100644
+--- a/graph/tags_unit_test.go
++++ b/graph/tags_unit_test.go
+@@ -6,7 +6,7 @@ import (
+ 	"github.com/dotcloud/docker/runtime/graphdriver"
+ 	_ "github.com/dotcloud/docker/runtime/graphdriver/vfs" // import the vfs driver so it is used in the tests
  	"github.com/dotcloud/docker/utils"
 -	"github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 +	"archive/tar"
  	"io"
- 	"io/ioutil"
- 	"net"
-diff -uNr docker-0.9.0/integration/utils_test.go docker-0.9.0-1/integration/utils_test.go
---- docker-0.9.0/integration/utils_test.go	2014-03-10 12:57:10.000000000 -0400
-+++ docker-0.9.0-1/integration/utils_test.go	2014-03-11 10:35:31.429085241 -0400
-@@ -3,7 +3,7 @@
+ 	"os"
+ 	"path"
+diff --git a/integration/api_test.go b/integration/api_test.go
+index 26441a2..a313382 100644
+--- a/integration/api_test.go
++++ b/integration/api_test.go
+@@ -21,7 +21,7 @@ import (
+ 	"github.com/dotcloud/docker/runconfig"
+ 	"github.com/dotcloud/docker/runtime"
+ 	"github.com/dotcloud/docker/utils"
+-	"github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
++	"archive/tar"
+ )
+ 
+ func TestGetEvents(t *testing.T) {
+diff --git a/integration/utils_test.go b/integration/utils_test.go
+index 8ad6ccb..5b16f2a 100644
+--- a/integration/utils_test.go
++++ b/integration/utils_test.go
+@@ -3,7 +3,7 @@ package docker
  import (
  	"bytes"
  	"fmt"
@@ -82,10 +102,11 @@ diff -uNr docker-0.9.0/integration/utils_test.go docker-0.9.0-1/integration/util
  	"io"
  	"io/ioutil"
  	"net/http"
-diff -uNr docker-0.9.0/utils/tarsum.go docker-0.9.0-1/utils/tarsum.go
---- docker-0.9.0/utils/tarsum.go	2014-03-10 12:57:10.000000000 -0400
-+++ docker-0.9.0-1/utils/tarsum.go	2014-03-11 10:35:44.731024753 -0400
-@@ -5,7 +5,7 @@
+diff --git a/utils/tarsum.go b/utils/tarsum.go
+index 67e94aa..5132194 100644
+--- a/utils/tarsum.go
++++ b/utils/tarsum.go
+@@ -5,7 +5,7 @@ import (
  	"compress/gzip"
  	"crypto/sha256"
  	"encoding/hex"
@@ -94,15 +115,3 @@ diff -uNr docker-0.9.0/utils/tarsum.go docker-0.9.0-1/utils/tarsum.go
  	"hash"
  	"io"
  	"sort"
-diff -uNr docker-0.9.0/utils_test.go docker-0.9.0-1/utils_test.go
---- docker-0.9.0/utils_test.go	2014-03-10 12:57:10.000000000 -0400
-+++ docker-0.9.0-1/utils_test.go	2014-03-11 10:35:55.151977365 -0400
-@@ -2,7 +2,7 @@
- 
- import (
- 	"bytes"
--	"github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
-+	"archive/tar"
- 	"io"
- )
- 


### PR DESCRIPTION
I had to regenerate `upstream-patched-archive-tar.patch`, and I used git so the format is slightly different.  Seems to be working well locally for me, but I'm still new to docker.
